### PR TITLE
[MAINT] Add return type annotations to remaining public functions

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -22,6 +22,8 @@ NEW
 Fixes
 -----
 
+- :bdg-dark:`Code` Fix the deprecated ``nilearn.interfaces.bids.save_glm_to_bids`` redirect silently returning ``None`` instead of the fitted model, because it called the relocated :func:`~glm.save_glm_to_bids` without returning its result (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Fix ``examples/04_glm_first_level/plot_bids_features.py``, ``doc/get_data_examples.py``, and ``doc/visual_testing/reporter_visual_inspection_suite.py`` downloading the full FSL derivatives for the ``bart`` and ``taskswitch`` tasks of the ``ds000030`` dataset in addition to ``stopsignal``, because the ``*task-task*`` exclusion filter did not match the ``derivatives/task/sub-*/taskswitch.feat`` folder name; switch to ``inclusion_filters`` to only fetch the files needed for the ``stopsignal`` analysis (:gh:`6432` by `Rémi Gau`_).
 
 - :bdg-warning:`Test` Fix the ``test_html`` GitHub Actions workflow to set ``NILEARN_DATA`` to the same path used to restore its dataset cache, and add ``NILEARN_DATA`` to ``tox.ini``'s shared ``passenv`` list so ``tox`` actually forwards it to the ``generate_html``/``test_html`` environments, since without it nilearn's fetchers default to ``~/nilearn_data`` instead and every dataset was silently re-downloaded from the network on every run regardless of whether the cache was restored (:gh:`6427` by `Rémi Gau`_).
@@ -61,6 +63,8 @@ Changes
 -------
 
 - :bdg-dark:`Code` Add return type annotations to :func:`~datasets.fetch_icbm152_2009`, :func:`~datasets.fetch_icbm152_brain_gm_mask`, :func:`~datasets.fetch_oasis_vbm`, :func:`~image.crop_img`, :func:`~plotting.plot_carpet`, and to internal helpers ``nilearn.conftest.check_parameters_doctring``, ``nilearn.conftest.check_methods_docstring``, ``nilearn.image.image.smooth_array``, and ``nilearn.surface.surface.combine_hemispheres_meshes`` (:gh:`6438` by `Rémi Gau`_).
+
+- :bdg-dark:`Code` Add return type annotations to :func:`~glm.first_level.check_design_matrix`, :func:`~glm.second_level.non_parametric_inference`, and :func:`~mass_univariate.permuted_ols` (:gh:`XXXX` by `Rémi Gau`_).
 
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -434,7 +434,9 @@ def make_first_level_design_matrix(
     return design_matrix
 
 
-def check_design_matrix(design_matrix):
+def check_design_matrix(
+    design_matrix: pd.DataFrame,
+) -> tuple[pd.Index, np.ndarray, list[str]]:
     """Check that the provided DataFrame is indeed a valid design matrix \
     descriptor, and returns a triplet of fields.
 

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -977,7 +977,7 @@ def non_parametric_inference(
     verbose=0,
     threshold=None,
     tfce=False,
-):
+) -> Nifti1Image | SurfaceImage | dict[str, Nifti1Image | SurfaceImage]:
     """Generate p-values corresponding to the contrasts provided \
     based on permutation testing.
 

--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -4,11 +4,16 @@ TODO: (nilearn >=0.15.0) remove
 """
 
 import warnings
+from typing import TYPE_CHECKING
 
 from nilearn._utils.logger import find_stack_level
 
+if TYPE_CHECKING:
+    from nilearn.glm.first_level import FirstLevelModel
+    from nilearn.glm.second_level import SecondLevelModel
 
-def save_glm_to_bids(*args, **kwgars):
+
+def save_glm_to_bids(*args, **kwgars) -> "FirstLevelModel | SecondLevelModel":
     """Redirect to save_glm_to_bids from nilearn.glm."""
     from nilearn.glm.io import save_glm_to_bids as sgtb
 
@@ -23,4 +28,4 @@ def save_glm_to_bids(*args, **kwgars):
         category=FutureWarning,
         stacklevel=find_stack_level(),
     )
-    sgtb(*args, **kwgars)
+    return sgtb(*args, **kwgars)

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -309,7 +309,7 @@ def permuted_ols(
     tfce=False,
     threshold=None,
     output_type="dict",
-):
+) -> dict[str, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Massively univariate group analysis with permuted OLS.
 
     Tested variates are independently fitted to target variates descriptors
@@ -734,7 +734,7 @@ def permuted_ols(
             return np.asarray([]), scores_original_data.T, np.asarray([])
 
         out = {"t": scores_original_data.T}
-        if tfce:
+        if tfce and tfce_original_data is not None:
             out["tfce"] = tfce_original_data.T
         return out
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,8 @@ ignore_imports = [
     "nilearn.plotting.tests.* -> nilearn._utils.data_gen",  # allowed in tests
     "nilearn.plotting.matrix.* -> nilearn.glm.**",
     "nilearn.interfaces.bids.glm -> nilearn.glm.io",  # TODO: (nilearn >= 0.15.0) remove
+    "nilearn.interfaces.bids.glm -> nilearn.glm.first_level",  # TODO: (nilearn >= 0.15.0) remove
+    "nilearn.interfaces.bids.glm -> nilearn.glm.second_level",  # TODO: (nilearn >= 0.15.0) remove
     "nilearn.interfaces.tests.test_glm -> nilearn.glm.first_level"  # TODO: (nilearn >= 0.15.0) remove
 ]
 # ** utils:
@@ -241,6 +243,8 @@ ignore_imports = [
     "nilearn.plotting.tests.* -> nilearn._utils.data_gen",  # allowed in tests
     "nilearn.plotting.matrix.* -> nilearn.glm.**",
     "nilearn.interfaces.bids.glm -> nilearn.glm.io",  # TODO: (nilearn >= 0.15.0) remove
+    "nilearn.interfaces.bids.glm -> nilearn.glm.first_level",  # TODO: (nilearn >= 0.15.0) remove
+    "nilearn.interfaces.bids.glm -> nilearn.glm.second_level",  # TODO: (nilearn >= 0.15.0) remove
     "nilearn.interfaces.tests.test_glm -> nilearn.glm.first_level",  # TODO: (nilearn >= 0.15.0) remove
     # additional on top of those of "main architecture"
     "nilearn.plotting.tests.test_img_comparisons -> nilearn._utils.data_gen",  # allowed in tests


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this pull request. -->
- Related to #3568

Stacked on top of nilearn/nilearn#6438 — only the last commit is new to this PR; it will show as a diff against `main` including #6438's changes until that one merges. Once #6438 merges into `nilearn/nilearn:main`, this PR should be retargeted there.

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Use `nilearn.utils.all_functions()` to identify every public function (excluding `nilearn.plotting`) still missing a return type annotation, and annotate the four found: `check_design_matrix`, `non_parametric_inference`, `save_glm_to_bids` (the deprecated `nilearn.interfaces.bids` redirect), and `permuted_ols`.
- Fix a real bug surfaced by annotating the deprecated `save_glm_to_bids` redirect in `nilearn.interfaces.bids.glm`: it called the relocated `nilearn.glm.io.save_glm_to_bids` without returning its result, so it always returned `None` instead of the fitted model. Fixed by returning the delegated call, and extended `pyproject.toml`'s import-linter `ignore_imports` (mirroring the existing exception already there for this same deprecated shim) for the `TYPE_CHECKING`-only import the annotation needs.
- Fix an `Optional`-narrowing mypy error in `permuted_ols` surfaced by its new return type, by making an existing invariant explicit rather than changing behavior.

## Summary by Sourcery

Add return type annotations to remaining public GLM and mass-univariate functions and fix issues revealed by stricter typing.

Bug Fixes:
- Ensure the deprecated nilearn.interfaces.bids.glm.save_glm_to_bids wrapper returns the fitted model instead of always returning None.
- Prevent possible misuse of TFCE scores in permuted_ols by only adding them to the output when they are computed and available.

Enhancements:
- Add precise return type annotations to check_design_matrix, permuted_ols, non_parametric_inference, and the deprecated save_glm_to_bids redirect to improve type checking and API clarity.
- Extend import-linter configuration to ignore TYPE_CHECKING-only imports needed for the new annotations in nilearn.interfaces.bids.glm.
- Document the typing-related changes in the latest changelog entry.